### PR TITLE
Fix #7

### DIFF
--- a/sentier_glossary/main.py
+++ b/sentier_glossary/main.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from enum import Enum
 from functools import reduce
 from urllib.parse import urljoin
+import warnings
 
 import pandas as pd
 import requests
@@ -39,7 +40,11 @@ class GlossaryAPI:
         code = language_code or locale.getlocale()[0] or self._cfg.fallback_language
         if isinstance(code, str) and len(code) >= 2:
             return code[:2].lower()
-        raise ValueError(f"Invalid language code {code} found; set locale or `default_language`")
+        warnings.warn(f"""
+            Unexpected language code encountered: '{code}'.
+            Switching to fallback: '{self._cfg.fallback_language}'
+        """)
+        return self._cfg.fallback_language
 
     def set_language_code(self, language_code: str) -> None:
         """Override language code from system locale or input argument."""

--- a/tests/unit/test_locale.py
+++ b/tests/unit/test_locale.py
@@ -32,7 +32,7 @@ def test_locale_lang_blank_string():
 @patch("locale.getlocale")
 def test_locale_invalid(loc: Mock):
     loc.return_value = ("p", "UTF-8")
-    with pytest.raises(ValueError):
+    with pytest.warns(UserWarning, match='Switching to fallback:'):
         g.GlossaryAPI()
 
 


### PR DESCRIPTION
Switch to fallback language (default is "en") if locale language code is "C" or other silliness.